### PR TITLE
hide pkgpath (security); +seeking decoder

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -23,6 +23,14 @@ var ErrUnsupportedSampleCodec = errors.New("unsupported sample codec")
 // in this interface.
 var AnySampleCodec = sample.Codec(-1)
 
+// IoReadSeekCloser just wraps io.ReadSeeker and io.Closer, as a convenience
+// for specifying a decoding function which can also seek (codec functions
+// always have a Close())
+type IoReadSeekerCloser interface {
+	io.ReadSeeker
+	io.Closer
+}
+
 // Codec represents a way of encoding and decoding sound.
 type Codec struct {
 	// Extensions lists the filename extensions which this codec claims to support.
@@ -38,7 +46,8 @@ type Codec struct {
 	// DefaultSampleCodec gives a default or preferred sample codec for the codec.
 	// Some codecs, such as perception based compressed codecs, don't really have
 	// a defined sample.Codec and should use AnySampleCodec for this field. Codecs
-	// which have only a decoder should also have AnySampleCodec in this field.
+	// which only have decoding capabilities should also have AnySampleCodec in this
+	// field.
 	DefaultSampleCodec sample.Codec
 
 	// Decoder tries to turn an io.ReadCloser into a sound.Source.  In the event
@@ -46,6 +55,10 @@ type Codec struct {
 	// decoding process for the resulting sound.Source, then the second return
 	// value should be AnySampleCodec (if the error return value is nil).
 	Decoder func(io.ReadCloser) (sound.Source, sample.Codec, error)
+
+	// SeekingDecoder is exactly like Decoder but returns a sound.SourceSeeker
+	// given an io.Reader which can seek and close.
+	SeekingDecoder func(IoReadSeekerCloser) (sound.SourceSeeker, sample.Codec, error)
 
 	// Encoder tries to turn an io.WriteCloser into a sound.Sink.
 	// The sample.Codec argument can specify the desired sample Codec.
@@ -58,6 +71,10 @@ type Codec struct {
 	// If the codec does not make use of a defined sample.Codec and c is
 	// not AnySampleCodec, then the function should return (nil, ErrUnsupporteSampleCodec).
 	RandomAccess func(ws io.ReadWriteSeeker, c sample.Codec) (sound.RandomAccess, error)
+}
+
+type codec struct {
+	Codec
 
 	// PkgPath is the package path of the codec functions above.  It is populated
 	// by RegisterCodec().  RegisterCodec() will only succeed if all non-nil codec
@@ -67,7 +84,7 @@ type Codec struct {
 	PkgPath string
 }
 
-var codecs []Codec
+var codecs []codec
 
 // ErrNonUniformCodec is an error indicating a codec has non
 // uniform package paths beween the available codec functions.
@@ -88,16 +105,19 @@ func pkgPath(v interface{}) string {
 // Although c is a pointer, a "deep" copy of c is added to the list of registered codecs.
 //
 // RegisterCodec returns a nil error upon success and ErrNonUniformCodec
-// if any two non-nil functions from c.{Encoder,Decoder,RandomAccess}
+// if any two non-nil functions from c.{Encoder,Decoder,SeekingDecoder,RandomAccess}
 // do not have the same package path.
 func RegisterCodec(c *Codec) error {
 
-	pkgPaths := make([]string, 0, 3)
+	pkgPaths := make([]string, 0, 4)
 	if c.Encoder != nil {
 		pkgPaths = append(pkgPaths, pkgPath(c.Encoder))
 	}
 	if c.Decoder != nil {
 		pkgPaths = append(pkgPaths, pkgPath(c.Decoder))
+	}
+	if c.SeekingDecoder != nil {
+		pkgPaths = append(pkgPaths, pkgPath(c.SeekingDecoder))
 	}
 	if c.RandomAccess != nil {
 		pkgPaths = append(pkgPaths, pkgPath(c.RandomAccess))
@@ -117,14 +137,16 @@ func RegisterCodec(c *Codec) error {
 		exts[i] = ext
 	}
 
-	codecs = append(codecs, Codec{
-		PkgPath:            thePath,
-		Extensions:         exts,
-		Sniff:              c.Sniff,
-		DefaultSampleCodec: c.DefaultSampleCodec,
-		Decoder:            c.Decoder,
-		Encoder:            c.Encoder,
-		RandomAccess:       c.RandomAccess})
+	codecs = append(codecs, codec{
+		PkgPath: thePath,
+		Codec: Codec{
+			Extensions:         exts,
+			Sniff:              c.Sniff,
+			DefaultSampleCodec: c.DefaultSampleCodec,
+			Decoder:            c.Decoder,
+			SeekingDecoder:     c.SeekingDecoder,
+			Encoder:            c.Encoder,
+			RandomAccess:       c.RandomAccess}})
 	return nil
 }
 
@@ -144,7 +166,7 @@ func CodecFor(ext string, pkgSel func(string) bool) (*Codec, error) {
 		for _, codExt := range c.Extensions {
 			if ext == codExt {
 				if pkgSel == nil || pkgSel(c.PkgPath) {
-					return c, nil
+					return &c.Codec, nil
 				}
 			}
 		}
@@ -168,18 +190,48 @@ func CodecFor(ext string, pkgSel func(string) bool) (*Codec, error) {
 //
 // 2. A sample.Codec which defined the data received in sound.Source.
 func Decoder(r io.ReadCloser, pkgSel func(string) bool) (sound.Source, sample.Codec, error) {
+	theCodec := sniff(r, pkgSel)
+	if theCodec == nil {
+		return nil, AnySampleCodec, ErrUnknownCodec
+	}
+	return theCodec.Decoder(r)
+}
+
+// SeekingDecoder is exactly like Decoder with respect to all arguments and
+// functionality with the following exceptions
+//
+// 1. The io.ReadCloser must be seekable.
+//
+// 2. It returns a sound.SourceSeeker rather than a sound.Source.
+func SeekingDecoder(r IoReadSeekerCloser, pkgSel func(string) bool) (sound.SourceSeeker, sample.Codec, error) {
+	theCodec := sniff(r, pkgSel)
+	if theCodec == nil {
+		return nil, AnySampleCodec, ErrUnknownCodec
+	}
+	return theCodec.SeekingDecoder(r)
+}
+
+func sniff(r io.Reader, pkgSel func(string) bool) *Codec {
 	br := bufio.NewReader(r)
 	var theCodec *Codec
 	for i := range codecs {
 		c := &codecs[i]
 		if c.Sniff != nil && c.Sniff(br) && (pkgSel == nil || pkgSel(c.PkgPath)) {
-			theCodec = c
+			theCodec = &c.Codec
 		}
 	}
-	if theCodec == nil {
-		return nil, AnySampleCodec, ErrUnknownCodec
-	}
-	return theCodec.Decoder(r)
+	return theCodec
+}
+
+// this helps us to deal with closing a bufio.Reader as above.
+// as bufio.Reader is needed for Sniff().
+type brCloser struct {
+	*bufio.Reader
+	io.Closer
+}
+
+func (brc *brCloser) Close() error {
+	return brc.Closer.Close()
 }
 
 // Encoder tries to turn an io.WriteCloser into a sound.Sink

--- a/codec.go
+++ b/codec.go
@@ -26,7 +26,7 @@ var AnySampleCodec = sample.Codec(-1)
 // IoReadSeekCloser just wraps io.ReadSeeker and io.Closer, as a convenience
 // for specifying a decoding function which can also seek (codec functions
 // always have a Close())
-type IoReadSeekerCloser interface {
+type IoReadSeekCloser interface {
 	io.ReadSeeker
 	io.Closer
 }
@@ -57,8 +57,8 @@ type Codec struct {
 	Decoder func(io.ReadCloser) (sound.Source, sample.Codec, error)
 
 	// SeekingDecoder is exactly like Decoder but returns a sound.SourceSeeker
-	// given an io.Reader which can seek and close.
-	SeekingDecoder func(IoReadSeekerCloser) (sound.SourceSeeker, sample.Codec, error)
+	// given an io.ReadSeekClose.
+	SeekingDecoder func(IoReadSeekCloser) (sound.SourceSeeker, sample.Codec, error)
 
 	// Encoder tries to turn an io.WriteCloser into a sound.Sink.
 	// The sample.Codec argument can specify the desired sample Codec.
@@ -203,7 +203,7 @@ func Decoder(r io.ReadCloser, pkgSel func(string) bool) (sound.Source, sample.Co
 // 1. The io.ReadCloser must be seekable.
 //
 // 2. It returns a sound.SourceSeeker rather than a sound.Source.
-func SeekingDecoder(r IoReadSeekerCloser, pkgSel func(string) bool) (sound.SourceSeeker, sample.Codec, error) {
+func SeekingDecoder(r IoReadSeekCloser, pkgSel func(string) bool) (sound.SourceSeeker, sample.Codec, error) {
 	theCodec := sniff(r, pkgSel)
 	if theCodec == nil {
 		return nil, AnySampleCodec, ErrUnknownCodec


### PR DESCRIPTION
This PR adds a SeekingDecoder codec function;

It also hides the Codec.PkgPath, the mechanism that consumers use to 
control what codec gets used in what case.

Seeking follow-up discussion, as the idea of the role of Seeking in the interface hasn't converged.

Also, the pkgSel mechanism has received no comment.  It gives callers full control, requires codec implementations place encoding/decoding functions in one package.  This PR enforces moreover
that no-one can (easily) hack the package path associated with a codec.

Comments/thoughts appreciated. 