### PR TITLE
Fixes some known issues, hopefully all

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -199,7 +199,7 @@ func sniff(r io.ReadCloser, pkgSel func(string) bool) (Codec, *brCloser) {
 	var theCodec Codec
 	for i := range codecs {
 		c := &codecs[i]
-		if c.Sniff != nil && c.Sniff(br) && (pkgSel == nil || pkgSel(c.pkgPath)) {
+		if c.Sniff(br) && (pkgSel == nil || pkgSel(c.pkgPath)) {
 			theCodec = c.Codec
 		}
 	}

--- a/codec_test.go
+++ b/codec_test.go
@@ -5,11 +5,13 @@ import (
 )
 
 func TestRegister(t *testing.T) {
-	RegisterCodec(NullCodec)
+	RegisterCodec(NullCodec{})
 }
 
 // don't know how to easily do this without actual codecs,
 // perhap we test more thoroughly in other packages?
+//
+// For boot strapping some stuff is tested out of the repo.
 
 /*
 func TestDecoder(t *testing.T) {

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,19 @@
+package codec
+
+import "testing"
+
+// TBD
+func TestRegister(t *testing.T) {
+}
+
+func TestDecoder(t *testing.T) {
+}
+
+func TestSeekingDecoder(t *testing.T) {
+}
+
+func TestEncoder(t *testing.T) {
+}
+
+func TestRandomAccess(t *testing.T) {
+}

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,11 +1,17 @@
 package codec
 
-import "testing"
+import (
+	"testing"
+)
 
-// TBD
 func TestRegister(t *testing.T) {
+	RegisterCodec(NullCodec)
 }
 
+// don't know how to easily do this without actual codecs,
+// perhap we test more thoroughly in other packages?
+
+/*
 func TestDecoder(t *testing.T) {
 }
 
@@ -17,3 +23,4 @@ func TestEncoder(t *testing.T) {
 
 func TestRandomAccess(t *testing.T) {
 }
+*/

--- a/codecs.md
+++ b/codecs.md
@@ -49,7 +49,8 @@ differ.
 
 ## collaborative imports
 The zikichombo.org/ext module contains collaborative importing 
-at the cost of licensing simplicity for consumers.
+at the cost of licensing simplicity for consumers.  Some 
+codecs are there.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module zikichombo.org/codec
 
-require zikichombo.org/sound v0.1.1-alpha.2
+require zikichombo.org/sound v0.1.3-alpha.2

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-zikichombo.org/sound v0.1.0-alpha.1 h1:1/tByuGvvertI6PlIt1bk9I0GnwrnwfDml/OSMPULFQ=
-zikichombo.org/sound v0.1.0-alpha.1/go.mod h1:akiZR7uLjsosCVBmP0t0hqsOgZ7iydYzjz92wFK2pLQ=
-zikichombo.org/sound v0.1.1-alpha.2 h1:x2bLgomOt5nKdX5feIkRn1+cthP8YLXLqa62cBmFfVs=
-zikichombo.org/sound v0.1.1-alpha.2/go.mod h1:akiZR7uLjsosCVBmP0t0hqsOgZ7iydYzjz92wFK2pLQ=
-zikichombo.org/sound v0.1.1 h1:ZBEmrafI255I9id8EoJKv1ZJ48QmI0bJE4TiNJ9Em8Q=
-zikichombo.org/sound v0.1.1/go.mod h1:akiZR7uLjsosCVBmP0t0hqsOgZ7iydYzjz92wFK2pLQ=
+zikichombo.org/sound v0.1.3-alpha.2 h1:VAYtcz14y/Rklv6YyOx31odGMva3Uf/0VvkcnuGL+Ws=
+zikichombo.org/sound v0.1.3-alpha.2/go.mod h1:akiZR7uLjsosCVBmP0t0hqsOgZ7iydYzjz92wFK2pLQ=

--- a/null.go
+++ b/null.go
@@ -8,38 +8,37 @@ import (
 	"zikichombo.org/sound/sample"
 )
 
-type nullCodec struct {
+// Type NullCodec is a type whose values implement Codec and
+// support nothing.  It is useful for embedding codec implementations
+// that only support some of the encoding/decoding functions.
+//
+type NullCodec struct {
 }
 
-// NullCodec implements a codec that supports nothing.  It is useful
-// for embedding in codec implementations that only support some of
-// encoding/decoding functions.
-var NullCodec Codec = nullCodec{}
-
-func (c nullCodec) Extensions() []string {
+func (c NullCodec) Extensions() []string {
 	return nil
 }
 
-func (c nullCodec) Sniff(*bufio.Reader) bool {
+func (c NullCodec) Sniff(*bufio.Reader) bool {
 	return false
 }
 
-func (c nullCodec) DefaultSampleCodec() sample.Codec {
+func (c NullCodec) DefaultSampleCodec() sample.Codec {
 	return AnySampleCodec
 }
 
-func (c nullCodec) Decoder(io.ReadCloser) (sound.Source, sample.Codec, error) {
+func (c NullCodec) Decoder(io.ReadCloser) (sound.Source, sample.Codec, error) {
 	return nil, AnySampleCodec, ErrUnsupportedFunction
 }
 
-func (c nullCodec) SeekingDecoder(IoReadSeekCloser) (sound.SourceSeeker, sample.Codec, error) {
+func (c NullCodec) SeekingDecoder(IoReadSeekCloser) (sound.SourceSeeker, sample.Codec, error) {
 	return nil, AnySampleCodec, ErrUnsupportedFunction
 }
 
-func (_ nullCodec) Encoder(w io.WriteCloser, c sample.Codec) (sound.Sink, error) {
+func (_ NullCodec) Encoder(w io.WriteCloser, c sample.Codec) (sound.Sink, error) {
 	return nil, ErrUnsupportedFunction
 }
 
-func (_ nullCodec) RandomAccess(ws IoReadWriteSeekCloser, c sample.Codec) (sound.RandomAccess, error) {
+func (_ NullCodec) RandomAccess(ws IoReadWriteSeekCloser, c sample.Codec) (sound.RandomAccess, error) {
 	return nil, ErrUnsupportedFunction
 }

--- a/null.go
+++ b/null.go
@@ -28,18 +28,18 @@ func (c nullCodec) DefaultSampleCodec() sample.Codec {
 	return AnySampleCodec
 }
 
-func (c nullCodec) Decoder() func(io.ReadCloser) (sound.Source, sample.Codec, error) {
-	return nil
+func (c nullCodec) Decoder(io.ReadCloser) (sound.Source, sample.Codec, error) {
+	return nil, AnySampleCodec, ErrUnsupportedFunction
 }
 
-func (c nullCodec) SeekingDecoder() func(IoReadSeekCloser) (sound.SourceSeeker, sample.Codec, error) {
-	return nil
+func (c nullCodec) SeekingDecoder(IoReadSeekCloser) (sound.SourceSeeker, sample.Codec, error) {
+	return nil, AnySampleCodec, ErrUnsupportedFunction
 }
 
-func (c nullCodec) Encoder() func(w io.WriteCloser, c sample.Codec) (sound.Sink, error) {
-	return nil
+func (_ nullCodec) Encoder(w io.WriteCloser, c sample.Codec) (sound.Sink, error) {
+	return nil, ErrUnsupportedFunction
 }
 
-func (c nullCodec) RandomAccess() func(ws IoReadWriteSeekCloser, c sample.Codec) (sound.RandomAccess, error) {
-	return nil
+func (_ nullCodec) RandomAccess(ws IoReadWriteSeekCloser, c sample.Codec) (sound.RandomAccess, error) {
+	return nil, ErrUnsupportedFunction
 }

--- a/null.go
+++ b/null.go
@@ -1,0 +1,45 @@
+package codec
+
+import (
+	"bufio"
+	"io"
+
+	"zikichombo.org/sound"
+	"zikichombo.org/sound/sample"
+)
+
+type nullCodec struct {
+}
+
+// NullCodec implements a codec that supports nothing.  It is useful
+// for embedding in codec implementations that only support some of
+// encoding/decoding functions.
+var NullCodec Codec = nullCodec{}
+
+func (c nullCodec) Extensions() []string {
+	return nil
+}
+
+func (c nullCodec) Sniff(*bufio.Reader) bool {
+	return false
+}
+
+func (c nullCodec) DefaultSampleCodec() sample.Codec {
+	return AnySampleCodec
+}
+
+func (c nullCodec) Decoder() func(io.ReadCloser) (sound.Source, sample.Codec, error) {
+	return nil
+}
+
+func (c nullCodec) SeekingDecoder() func(IoReadSeekCloser) (sound.SourceSeeker, sample.Codec, error) {
+	return nil
+}
+
+func (c nullCodec) Encoder() func(w io.WriteCloser, c sample.Codec) (sound.Sink, error) {
+	return nil
+}
+
+func (c nullCodec) RandomAccess() func(ws IoReadWriteSeekCloser, c sample.Codec) (sound.RandomAccess, error) {
+	return nil
+}


### PR DESCRIPTION
This re-do of codec uses an interface.  It was tested only for Decoder() via a flac implementation, for which a PR will be made in ext/ soon.

SeekingDecoder related issues are hopefully fixed as well, but not yet tested.

Testing was done offline from the repo to facilitate cross module stuff.

Intended to close #15 and for use in ext ogg/vorbis.
